### PR TITLE
Add missing slash to nginx config

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -31,7 +31,7 @@ http {
             proxy_set_header X-Real-IP $http_x_forwarded_for;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Host $server_name;
-            proxy_pass https://api.mixpanel.com;
+            proxy_pass https://api.mixpanel.com/;
         }
     }
 }


### PR DESCRIPTION
This fixes #1 . Without the trailing slash, mixpanel returns an invalid argument "POST object expects Content-Type multipart/form-data" error.