### PR TITLE
Add "Deploy on Railway" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ There are a few ways you can use this repo to deploy a server that can be use to
 ### Option 1: One-click Deploy
    - [Run on Google Cloud](https://deploy.cloud.run)
    - [Deploy to DigitalOcean](https://cloud.digitalocean.com/apps/new?repo=https://github.com/mixpanel/tracking-proxy/tree/master)
+   - [Deploy on Railway](https://railway.app/new/template?template=https://github.com/mixpanel/tracking-proxy&envs=PORT&PORTDefault=80)
    
 ### Option 2: Docker Image
    Assuming you have Docker installed on your system, you can do the following:


### PR DESCRIPTION
[Railway](https://railway.app) is a new simple and quick cloud provider. I have verified this link and deployed this repo on Railway by following this link. Mixpanel works well, events are sent and received. In order to deploy the repo on Railway, you will need to fork it to your Github account in their UI.