### PR TITLE
Omit keywords

### DIFF
--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -1,7 +1,7 @@
 spec:
- name: mixpanel-api-proxy
+ name: tracking-proxy
  services:
- - name: mixpanel-api-proxy
+ - name: tracking-proxy
    git:
      branch: master
      repo_clone_url: https://github.com/mixpanel/tracking-proxy.git

--- a/app.json
+++ b/app.json
@@ -1,5 +1,5 @@
 {
-	"name": "mixpanel-tracking-proxy",
+	"name": "tracking-proxy",
 	"options": {
 		"allow-unauthenticated": true,
 		"memory": "512Mi",

--- a/render.yaml
+++ b/render.yaml
@@ -1,6 +1,6 @@
 services:
   - type: web
-    name: nginx-proxy
+    name: tracking-proxy
     env: docker
     plan: starter
     dockerfilePath: './Dockerfile'


### PR DESCRIPTION
TIL: certain adblockers (like ublock origin) are fuzzy matching on keywords like `mixpanel` in the URL, _in addition to_ maintaining filter lists like `api.mixpanel.com`, `cdn.mxpnl.com`,  etc...

the "one click deploy" scripts (for example on google cloud run) will grab the name of the service from the metadata (`app.json`) in this repo which _ends up_ as a subdomain for the public URL that gets created... so:

```
{ "name": "mixpanel-tracking-proxy"}
```

spits out a URL like:

`https://mixpanel-tracking-proxy-lmozz6xkha-uc.a.run.app/`

out of the box, this gets blocked (by the more sophisticated adblockers).

while it's not hard to change the name of your service, i think the one-click deploys should aim to work without too much fuss... so this PR just gets rid of the `mixpanel` keywords in the service name for the various one click providers... so we don't end up with an endpoint that gets flagged by some adblockers.