### PR TITLE
Fix Digital Ocean one-click deploy link

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ click on a button below to deploy to your favorite cloud provider:
 [Google Cloud Deploy]: https://deploy.cloud.run
 
 [Digital Ocean Btn]: https://www.deploytodo.com/do-btn-blue.svg
-[Digital Ocean Deploy]: https://cloud.digitalocean.com/apps/new?repo=https://github.com/mixpanel/tracking-proxy
+[Digital Ocean Deploy]: https://cloud.digitalocean.com/apps/new?repo=https://github.com/mixpanel/tracking-proxy/tree/master
 
 [Railway Btn]: https://binbashbanana.github.io/deploy-buttons/buttons/remade/railway.svg
 [Railway Deploy]: https://railway.app/template/_RaWSW


### PR DESCRIPTION
Without this fix clicking the button give this error message:

<img width="647" alt="Screenshot 2023-10-12 at 23 25 18" src="https://github.com/mixpanel/tracking-proxy/assets/350222/2e7dff8d-0b01-4f34-a1ba-5c57a20d6270">
